### PR TITLE
Using log level info instead warning for this message

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/periodicreincarnation/RegEx.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicreincarnation/RegEx.java
@@ -151,7 +151,7 @@ public class RegEx {
                 regExCronTab = new CronTab(this.getCronTime());
             }
         } catch (ANTLRException e) {
-            LOGGER.warning("RegEx cron tab could not be parsed! Trying to use global instead...");
+            LOGGER.fine("RegEx cron tab could not be parsed or is empty! Trying to use global instead...");
         }
         try {
             if (PeriodicReincarnationGlobalConfiguration.get().getCronTime() != null) {


### PR DESCRIPTION
We found a lot of warnings in our log file. We don't use reg ex cron tab entries only a global crontab entry.
