### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ There is also the additional option to restart jobs if the last build has failed
 This plugin can be useful when something temporary may be causing a build to fail.
 For instance:
 
-	- there was not enough space on the hard disk. Upon that event a disk clean can be automatically performed.
+- there was not enough space on the hard disk. Upon that event a disk clean can be automatically performed.
 	
-	- there was a communication problem with a slave. A script to disconnect such agent is provided.
+- there was a communication problem with a slave. A script to disconnect such agent is provided.
 
-	- there was some incompatibility of some kind
+- there was some incompatibility of some kind
 
 Another example:
 It is easy to periodically restart all jobs that have failed because of some arbitrary "error_failing_the_build". Just activate the plugin, set the cron time ("* * * * *" for every minute), and add this "error_failing_the_build" as regular expression.


### PR DESCRIPTION
Markdown formats indentation of 4 spaces or one tab as code, so removed that from the list which didn't look like it was intentional.
