### PR TITLE
don't rebuild on own messages

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/periodicreincarnation/Utils.java
+++ b/src/main/java/org/jenkinsci/plugins/periodicreincarnation/Utils.java
@@ -196,12 +196,15 @@ public class Utils {
         }
         boolean rslt = false;
         BufferedReader reader = null;
+        // pattern to filter out our own messages in the logs so we don't create a respawn loop
+        Pattern prPattern = Pattern.compile(".*Periodic Reincarnation.*");
         try {
             reader = new BufferedReader(new FileReader(file));
             String line;
             while ((line = reader.readLine()) != null) {
                 final Matcher matcher = pattern.matcher(line);
-                if (matcher.find()) {
+                final Matcher prMatcher = prPattern.matcher(line);
+                if (matcher.find() && !prMatcher.find()) {
                     // we have a hit
                     rslt = true;
                     if (abortAfterFirstHit) {


### PR DESCRIPTION
Under certain conditions, the PeriodicReincarnation plugin ends up creating a build loop.  Process:

1.  A build fails with an error processable by a PeriodicReincarnation regex.
2.  The next build starts out with a notice about said PeriodicReincarnation regex failure.
3.  The new build fails, but *not* because of that PeriodicReincarnation regex.
4.  The build gets re-queued because the PeriodicReincarnation plugin finds the error that it inserted, not an actual failure message.
5.  Rinse and repeat until the build is fixed.

This change breaks the cycle by ignoring any messages added by the PeriodicReincarnation plugin when checking the file for error messages.